### PR TITLE
Update slug edit

### DIFF
--- a/app/controllers/dashboard/items_controller.rb
+++ b/app/controllers/dashboard/items_controller.rb
@@ -62,15 +62,22 @@ class Dashboard::ItemsController < Dashboard::BaseController
     if current_admin?
     @merchant = User.find_by(slug: params[:merchant_slug])
     end
-    
+
     @item = Item.find_by(slug: params[:slug])
+    old_name = @item.name
 
     ip = item_params
+
     if ip[:image].empty?
       ip[:image] = 'https://picsum.photos/200/300/?image=524'
     end
     ip[:active] = true
     @item.update(ip)
+
+    unless item_params[:name] == old_name
+     @item[:slug] = @item.slug_update(item_params[:name])
+    end
+  
     if @item.save
       flash[:success] = "#{@item.name} has been updated!"
       if current_admin?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,10 @@ class UsersController < ApplicationController
     render file: 'errors/not_found', status: 404 unless current_user == @user || current_admin?
 
     @user.update(user_params)
+    
+      if user_params.include?(:email)
+       @user[:slug] = @user.slug_update(user_params[:email])
+      end
 
     if @user.save
       session[:slug] = @user.slug

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,11 +24,13 @@ class UsersController < ApplicationController
 
     render file: 'errors/not_found', status: 404 unless current_user == @user || current_admin?
 
+    old_email = @user.email
+
     @user.update(user_params)
-    
-      if user_params.include?(:email)
-       @user[:slug] = @user.slug_update(user_params[:email])
-      end
+
+    unless user_params[:email] == old_email
+      @user[:slug] = @user.slug_update(user_params[:email])
+    end
 
     if @user.save
       session[:slug] = @user.slug

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -48,6 +48,10 @@ class Item < ApplicationRecord
     slug
   end
 
+  def slug_update(name)
+    name.downcase.gsub(/[!@%&"_.?*()#$^~ ]/,'-').delete(" ") + SecureRandom.uuid
+  end
+
   private
 
   def generate_slug

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,10 +119,15 @@ class User < ApplicationRecord
     slug
   end
 
+  def slug_update(email)
+    email.downcase.gsub(/[!@%&"_.]/,'-')
+  end
+
   private
 
   def generate_slug
      self.slug = email.downcase.gsub(/[!@%&"_.]/,'-') if email
   end
+
 
 end

--- a/spec/features/admin/user_show_spec.rb
+++ b/spec/features/admin/user_show_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe 'Admin User Show workflow', type: :feature do
 
       user_check = User.find(@user_1.id)
       expect(user_check.password_digest).to_not eq(@user_1.password_digest)
+      
+      expect(user_check.slug.include?("email-2")).to be true
 
       expect(current_path).to eq(admin_user_path(user_check.slug))
       expect(page).to have_content("Profile Page for #{user_check.name}")

--- a/spec/features/admin/user_show_spec.rb
+++ b/spec/features/admin/user_show_spec.rb
@@ -51,9 +51,7 @@ RSpec.describe 'Admin User Show workflow', type: :feature do
 
       user_check = User.find(@user_1.id)
       expect(user_check.password_digest).to_not eq(@user_1.password_digest)
-      
-      expect(user_check.slug.include?("email-2")).to be true
-
+      expect(user_check.slug).to eq("email-2-gmail-com")
       expect(current_path).to eq(admin_user_path(user_check.slug))
       expect(page).to have_content("Profile Page for #{user_check.name}")
       expect(page).to have_content(user_check.email)

--- a/spec/features/merchant/dashboard_items_spec.rb
+++ b/spec/features/merchant/dashboard_items_spec.rb
@@ -238,6 +238,10 @@ RSpec.describe 'Merchant Dashboard Items page' do
         end
         expect(page).to have_content("New #{@item.name} has been updated!")
 
+        item_check = Item.find(@item.id)
+
+        expect(item_check.slug.include?('new')).to be true
+
         within "#item-#{@item.id}" do
           expect(page).to have_content("Name: New #{@item.name}")
           expect(page).to have_content("Price: #{number_to_currency(7654.32)}")
@@ -264,9 +268,13 @@ RSpec.describe 'Merchant Dashboard Items page' do
       after :each do
         placeholder_image = 'https://picsum.photos/200/300/?image=524'
         image = 'https://picsum.photos/200/300/?image=5'
-
+    
         fill_in :item_image, with: ""
         click_button 'Update Item'
+
+        item_check = Item.find(@item.id)
+
+        expect(item_check.slug).to eq(@item.slug)
 
         within "#item-#{@item.id}" do
           expect(page.find("#item-#{@item.id}-image")['src']).to have_content(placeholder_image)
@@ -294,6 +302,10 @@ RSpec.describe 'Merchant Dashboard Items page' do
         fill_in :item_price, with: ""
         fill_in :item_inventory, with: ""
         click_button 'Update Item'
+
+        item_check = Item.find(@item.id)
+
+        expect(item_check.slug).to eq(@item.slug)
 
         expect(page).to have_content("prohibited this item from being saved")
         expect(page).to have_content("Name can't be blank")

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'User Profile workflow', type: :feature do
 
         user_check = User.find(user.id)
         expect(user_check.password_digest).to_not eq(user.password_digest)
-
+        expect(user_check.slug.include?("email-2")).to be true
         expect(current_path).to eq(profile_path)
         expect(page).to have_content("Profile Page for #{user_check.name}")
         expect(page).to have_content(user_check.email)
@@ -93,7 +93,7 @@ RSpec.describe 'User Profile workflow', type: :feature do
 
         user_check = User.find(user.id)
         expect(user_check.password_digest).to eq(user.password_digest)
-
+        expect(user_check.slug.include?("email-2")).to be true
         expect(current_path).to eq(profile_path)
         expect(page).to have_content("Profile Page for #{user_check.name}")
         expect(page).to have_content(user_check.email)
@@ -118,6 +118,9 @@ RSpec.describe 'User Profile workflow', type: :feature do
 
         fill_in :user_email,	with: 'unique@gmail.com'
         click_button 'Update User'
+        user_check = User.find(user.id)
+
+        expect(user_check.slug.include?("ian-gmail-com")).to be true
 
         expect(current_path).to eq(user_path(user.slug))
         expect(page).to have_content('Profile update failed')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -176,6 +176,12 @@ RSpec.describe User, type: :model do
         user = create(:user, email: 'Dave_Johnson345@aol.com' )
         expect(user.slug).to eq('dave-johnson345-aol-com')
       end
-    end
+
+      it '.slug_update' do
+        user = create(:user)
+        email = "1234@34.com"
+        expect(user.slug_update(email)).to eq("1234-34-com")
+      end
+   end
   end
 end


### PR DESCRIPTION
Adds slug update method to User model and Item model
Adds logic to User and Item controller update methods to only update slug if item name or email 
  change 
Tested in dashboard item spec, user profile spec, merchant dashboard spec & admin user show spec

All tests passing 